### PR TITLE
Add Alfred 3 theme

### DIFF
--- a/Cobalt2-alfred3.x.alfredappearance
+++ b/Cobalt2-alfred3.x.alfredappearance
@@ -1,0 +1,61 @@
+{
+  "alfredtheme" : {
+    "result" : {
+      "textSpacing" : 4,
+      "subtext" : {
+        "size" : 12,
+        "colorSelected" : "#000000FF",
+        "font" : "Menlo",
+        "color" : "#606B70FF"
+      },
+      "shortcut" : {
+        "size" : 20,
+        "colorSelected" : "#0E2232FF",
+        "font" : "Menlo",
+        "color" : "#4C78FFFF"
+      },
+      "backgroundSelected" : "#FFCF02FF",
+      "text" : {
+        "size" : 21,
+        "colorSelected" : "#000000FF",
+        "font" : "Menlo",
+        "color" : "#CDD6DBFF"
+      },
+      "iconPaddingHorizontal" : 15,
+      "paddingVertical" : 15,
+      "iconSize" : 45
+    },
+    "search" : {
+      "paddingVertical" : 30,
+      "background" : "#00000000",
+      "spacing" : 0,
+      "text" : {
+        "size" : 48,
+        "colorSelected" : "#000000FF",
+        "font" : "Helvetica Neue",
+        "color" : "#F5CF03FF"
+      },
+      "backgroundSelected" : "#B2D7FFFF"
+    },
+    "window" : {
+      "color" : "#1B2C3FFF",
+      "paddingHorizontal" : 45,
+      "width" : 560,
+      "borderPadding" : 0,
+      "borderColor" : "#F3C600FF",
+      "blur" : 0,
+      "roundness" : 4,
+      "paddingVertical" : 30
+    },
+    "credit" : "Wes Bos / Joseph Fusco",
+    "separator" : {
+      "color" : "#00000000",
+      "thickness" : 0
+    },
+    "scrollbar" : {
+      "color" : "##FFAE4F",
+      "thickness" : 0
+    },
+    "name" : "Cobalt2"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Super great theme for [Alfred](http://www.alfredapp.com/).
 Based on the [Cobalt2 theme for Sublime Text](https://github.com/wesbos/cobalt2/).
-Original by Wes Bos, updated by Nicolas Goerlach.
+Original by Wes Bos, updated by Nicolas Goerlach & Joseph Fusco.
 
 ## Install
 Download this repository and double click on the file that corresponds with your version of Alfred. Alfred will automatically install it for you!

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,17 @@
 # Cobalt 2 theme for Alfred
 
-Super great theme for [Alfred](http://www.alfredapp.com/). 
-Based on the [Cobalt2 theme for Sublime Text](https://github.com/wesbos/cobalt2/).  
+Super great theme for [Alfred](http://www.alfredapp.com/).
+Based on the [Cobalt2 theme for Sublime Text](https://github.com/wesbos/cobalt2/).
 Original by Wes Bos, updated by Nicolas Goerlach.
 
-To install, download `Cobalt2-alfred2.x.alfredappearance` for alfred 2.x and double click. Alfred will automatically install it for you.
+## Install
+Download this repository and double click on the file that corresponds with your version of Alfred. Alfred will automatically install it for you!
+
+### Alfred 2.x
+Use `Cobalt2-alfred2.x.alfredappearance`.
+
+### Alfred 3.x
+Use `Cobalt2-alfred3.x.alfredappearance`.
 
 Enjoy!
 


### PR DESCRIPTION
Alfred 3 adds a bunch of stuff to theming such as padding/spacing and what not. I don't think theme that are made in Alfred 3 are backwards compatible but I could be wrong - unfortunately I wasn't able to find any info on it. For that reason I have added a separate file just for Alfred 3.

Search font is "Helvetica Neue" and everything else is "Menlo".

## Screenshot

![screen shot 2017-09-05 at 15 05 54](https://user-images.githubusercontent.com/6676674/30079108-139e97f2-924d-11e7-94ca-56d2ba72f519.png)
